### PR TITLE
Add justfile with serve/build/pull/clean commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,22 @@
+public_dir := "public"
+
+# 預設
+default: build
+
+# 本地開發伺服器（含 draft、區網可存取）
+serve:
+    hugo server -D --bind 0.0.0.0
+
+# 建置生產版（清理 + 壓縮）
+build:
+    hugo --gc --minify
+
+# 拉取最新（含 submodule）
+pull:
+    git pull --recurse-submodules
+
+# 完整清理
+clean:
+    rm -rf {{public_dir}}
+    rm -rf resources/_gen
+    hugo --gc

--- a/justfile
+++ b/justfile
@@ -1,5 +1,3 @@
-public_dir := "public"
-
 # 預設
 default: build
 
@@ -17,6 +15,6 @@ pull:
 
 # 完整清理
 clean:
-    rm -rf {{public_dir}}
+    rm -rf public
     rm -rf resources/_gen
     hugo --gc

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # 預設
-default: build
+default: serve
 
 # 本地開發伺服器（含 draft、區網可存取）
 serve:


### PR DESCRIPTION
## Summary

Add a `justfile` to simplify common development tasks:

| Command | Action |
|---------|--------|
| `just serve` | `hugo server -D --bind 0.0.0.0` — local dev server (drafts included, accessible from LAN) |
| `just build` | `hugo --gc --minify` — production build |
| `just pull` | `git pull --recurse-submodules` — pull latest including submodules |
| `just clean` | Remove `public/` + `resources/_gen` + run `hugo --gc` — full cleanup |

Deploy is intentionally omitted since Cloudflare Pages auto-deploys on push.
Theme update is intentionally omitted since Renovate handles submodule updates.

(Generated by AI Agent)