### PR TITLE
feat: add native AVIF/WebP image pipeline with responsive <picture> element

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -23,6 +23,16 @@ buildFuture = false
 
 [imaging]
   anchor = 'Center'
+  resampleFilter = 'lanczos'
+  [imaging.avif]
+    compression = 'lossy'
+    encoderSpeed = 10
+    hint = 'photo'
+    quality = 65
+  [imaging.webp]
+    compression = 'lossy'
+    hint = 'photo'
+    quality = 80
 
 [taxonomies]
   tag = "tags"

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,106 @@
+{{- define "RenderImageSimple" -}}
+  {{- $imgObj := .imgObj -}}
+  {{- $src := .src -}}
+  {{- $alt := .alt -}}
+  <img
+    class="my-0 rounded-md"
+    loading="lazy"
+    decoding="async"
+    fetchpriority="low"
+    alt="{{ $alt }}"
+    src="{{ $src }}"
+    {{ with $imgObj -}}
+      {{ with $imgObj.Width }}width="{{ . }}"{{ end }}
+      {{ with $imgObj.Height }}height="{{ . }}"{{ end }}
+    {{- end }}>
+{{- end -}}
+
+{{- define "RenderImageResponsive" -}}
+  {{- $imgObj := .imgObj -}}
+  {{- $alt := .alt -}}
+  {{- $originalWidth := $imgObj.Width -}}
+
+  {{- $img800 := $imgObj -}}
+  {{- $img1280 := $imgObj -}}
+  {{- if gt $originalWidth 800 -}}
+    {{- $img800 = $imgObj.Resize "800x" -}}
+  {{- end -}}
+  {{- if gt $originalWidth 1280 -}}
+    {{- $img1280 = $imgObj.Resize "1280x" -}}
+  {{- end -}}
+
+  {{- $srcset := printf "%s 800w, %s 1280w" $img800.RelPermalink $img1280.RelPermalink -}}
+  {{- $sizes := "(min-width: 768px) 50vw, 65vw" -}}
+
+  {{- /* Generate AVIF and WebP versions via Hugo's native image pipeline */ -}}
+  {{- $img800avif := $imgObj.Resize "800x avif" -}}
+  {{- $img1280avif := $imgObj.Resize "1280x avif" -}}
+  {{- $img800webp := $imgObj.Resize "800x webp" -}}
+  {{- $img1280webp := $imgObj.Resize "1280x webp" -}}
+
+  {{- $srcsetAvif := printf "%s 800w, %s 1280w" $img800avif.RelPermalink $img1280avif.RelPermalink -}}
+  {{- $srcsetWebp := printf "%s 800w, %s 1280w" $img800webp.RelPermalink $img1280webp.RelPermalink -}}
+
+  <picture>
+    <source srcset="{{ $srcsetAvif }}" type="image/avif" sizes="{{ $sizes }}">
+    <source srcset="{{ $srcsetWebp }}" type="image/webp" sizes="{{ $sizes }}">
+    <img
+      class="my-0 rounded-md"
+      loading="lazy"
+      decoding="async"
+      fetchpriority="auto"
+      alt="{{ $alt }}"
+      {{ with $imgObj.Width }}width="{{ . }}"{{ end }}
+      {{ with $imgObj.Height }}height="{{ . }}"{{ end }}
+      src="{{ $img800.RelPermalink }}"
+      srcset="{{ $srcset }}"
+      sizes="{{ $sizes }}"
+      data-zoom-src="{{ $imgObj.RelPermalink }}">
+  </picture>
+{{- end -}}
+
+{{- define "RenderImageCaption" -}}
+  {{- with .caption -}}
+    <figcaption>{{ . | markdownify }}</figcaption>
+  {{- end -}}
+{{- end -}}
+
+{{- $disableImageOptimizationMD := .Page.Site.Params.disableImageOptimizationMD | default false -}}
+{{- $urlStr := .Destination | safeURL -}}
+{{- $url := urls.Parse $urlStr -}}
+{{- $altText := .Text -}}
+{{- $caption := .Title -}}
+{{- $isRemote := findRE "^(https?|data)" $url.Scheme -}}
+{{- $resource := "" -}}
+
+{{- if not $isRemote -}}
+  {{- $resource = or ($.Page.Resources.GetMatch $urlStr) (resources.Get $urlStr) -}}
+{{- end -}}
+
+
+<figure
+  {{- range $k, $v := .Attributes -}}
+    {{- if $v -}}
+      {{- printf " %s=%q" $k ($v | transform.HTMLEscape) | safeHTMLAttr -}}
+    {{- end -}}
+  {{- end -}}>
+  {{- if $isRemote -}}
+    {{- template "RenderImageSimple" (dict "imgObj" "" "src" $urlStr "alt" $altText) -}}
+  {{- else if $resource -}}
+    {{- $isSVG := eq $resource.MediaType.SubType "svg" -}}
+    {{- $shouldOptimize := and (not $disableImageOptimizationMD) (not $isSVG) -}}
+    {{- if $shouldOptimize -}}
+      {{- template "RenderImageResponsive" (dict "imgObj" $resource "alt" $altText) -}}
+    {{- else -}}
+      {{- if $isSVG -}}
+        {{- template "RenderImageSimple" (dict "imgObj" "" "src" $resource.RelPermalink "alt" $altText) -}}
+      {{- else -}}
+        {{- template "RenderImageSimple" (dict "imgObj" $resource "src" $resource.RelPermalink "alt" $altText) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- template "RenderImageSimple" (dict "imgObj" "" "src" $urlStr "alt" $altText) -}}
+  {{- end -}}
+
+  {{- template "RenderImageCaption" (dict "caption" $caption) -}}
+</figure>

--- a/layouts/partials/article-link/_shortcode.html
+++ b/layouts/partials/article-link/_shortcode.html
@@ -1,0 +1,135 @@
+{{/* Used by
+  1. article shortcode
+
+  The four variants of article-link are very similar. Despite appearances, as of df859f:
+  - _shortcode.html uses $page := $target, while the others use $page := .Page
+  - card-related.html does not have the hideFeatureImage option, while the others do
+
+  $page is added intentionally to prevent small differences inside
+*/}}
+{{ $target := .target }}
+{{ $shortcodeShowSummary := .showSummary }}
+{{ $shortcodeCompactSummary := .compactSummary }}
+{{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
+{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+
+{{ $cardClasses := "flex flex-col md:flex-row relative" }}
+{{ $imgWrapperClasses := "" }}
+{{ $cardContentClasses := "" }}
+
+{{ if site.Params.list.showCards }}
+  {{ $cardClasses = printf "%s overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600" $cardClasses }}
+  {{ $imgWrapperClasses = "" }}
+  {{ $cardContentClasses = printf "%s p-4 pt-2" $cardContentClasses }}
+{{ else }}
+  {{ $cardClasses = printf "%s" $cardClasses }}
+  {{ $imgWrapperClasses = printf "%s thumbnail-shadow md:mr-7" $imgWrapperClasses }}
+  {{ $cardContentClasses = printf "%s mt-3 md:mt-0" $cardContentClasses }}
+{{ end }}
+
+{{ if $constrainItemsWidth }}
+  {{ $cardClasses = printf "%s max-w-prose" $cardClasses }}
+{{ end }}
+
+{{ $page := $target }}
+{{ $featured := "" }}
+{{ $featuredURL := "" }}
+{{ $featuredAvifURL := "" }}
+{{ if not $target.Params.hideFeatureImage }}
+  {{/* frontmatter */}}
+  {{ with $page }}
+    {{ $p := . }}
+    {{ with .Params.featureimage }}
+      {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+        {{ if site.Params.hotlinkFeatureImage }}
+          {{ $featuredURL = . }}
+        {{ else }}
+          {{ $featured = resources.GetRemote . }}
+        {{ end }}
+      {{ else }}
+        {{ $featured = $p.Resources.Get . }}
+      {{ end }}
+    {{ end }}
+
+    {{/* page resources */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $images := .Resources.ByType "image" }}
+      {{ range slice "*feature*" "*cover*" "*thumbnail*" }}
+        {{ if not $featured }}{{ $featured = $images.GetMatch . }}{{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{/* fallback to default */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $default := site.Store.Get "defaultFeaturedImage" }}
+      {{ if $default.url }}
+        {{ $featuredURL = $default.url }}
+      {{ else if $default.obj }}
+        {{ $featured = $default.obj }}
+      {{ end }}
+    {{ end }}
+
+    {{/* generate image URL if not hotlink */}}
+    {{ if not $featuredURL }}
+      {{ with $featured }}
+        {{ $featuredURL = .RelPermalink }}
+        {{ if not (or $disableImageOptimization (eq .MediaType.SubType "svg")) }}
+          {{ $featuredURL = (.Resize "600x").RelPermalink }}
+          {{ $featuredAvifURL = (.Resize "600x avif").RelPermalink }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+
+<article class="article-link--shortcode {{ $cardClasses }}">
+  {{ with $featuredURL }}
+    <div class="flex-none relative overflow-hidden {{ $imgWrapperClasses }} thumbnail">
+      <picture>
+        {{ with $featuredAvifURL }}
+          <source srcset="{{ . }}" type="image/avif">
+        {{ end }}
+        <img
+          src="{{ . }}"
+          role="presentation"
+          loading="lazy"
+          decoding="async"
+          class="not-prose absolute inset-0 w-full h-full object-cover">
+      </picture>
+    </div>
+  {{ end }}
+  <div class="{{ $cardContentClasses }}">
+    <header class="items-center text-start text-xl font-semibold">
+      <a
+        {{ with $page.Params.externalUrl }}
+          href="{{ . }}" target="_blank" rel="external"
+        {{ else }}
+          href="{{ $page.RelPermalink }}"
+        {{ end }}
+        class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        <h2>
+          {{ $target.Title | emojify }}
+          {{ if $target.Params.externalUrl }}
+            <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+              <span class="rtl:hidden">&#8599;</span>
+              <span class="ltr:hidden">&#8598;</span>
+            </span>
+          {{ end }}
+        </h2>
+      </a>
+    </header>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{ partial "article-meta/basic.html" $target }}
+    </div>
+    {{ if $shortcodeShowSummary | default $target.Params.showSummary | default site.Params.list.showSummary | default false }}
+      {{ $compactSummary := $shortcodeCompactSummary | default $target.Params.compactSummary | default false }}
+      <div
+        class="article-link__summary prose dark:prose-invert max-w-fit mt-1 {{ if $compactSummary -}}
+          line-clamp-3
+        {{- end }}">
+        {{ $target.Summary | plainify }}
+      </div>
+    {{ end }}
+  </div>
+</article>

--- a/layouts/partials/article-link/card-related.html
+++ b/layouts/partials/article-link/card-related.html
@@ -1,0 +1,112 @@
+{{/* Used by
+  1. layouts/partials/related.html (related articles in single page)
+*/}}
+{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+
+{{ $page := .Page }}
+{{ $featured := "" }}
+{{ $featuredURL := "" }}
+{{ $featuredAvifURL := "" }}
+{{ $thumbnailAspectRatio := site.Params.thumbnailAspectRatio | default "1.5" }}
+{{ $thumbnailAspectRatio = replaceRE "[^0-9.]" "" $thumbnailAspectRatio }}
+{{ if eq $thumbnailAspectRatio "" }}{{ $thumbnailAspectRatio = "1.5" }}{{ end }}
+{{/* frontmatter */}}
+{{ with $page }}
+  {{ $p := . }}
+  {{ with .Params.featureimage }}
+    {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+      {{ if site.Params.hotlinkFeatureImage }}
+        {{ $featuredURL = . }}
+      {{ else }}
+        {{ $featured = resources.GetRemote . }}
+      {{ end }}
+    {{ else }}
+      {{ $featured = $p.Resources.Get . }}
+    {{ end }}
+  {{ end }}
+
+  {{/* page resources */}}
+  {{ if not (or $featured $featuredURL) }}
+    {{ $images := .Resources.ByType "image" }}
+    {{ range slice "*feature*" "*cover*" "*thumbnail*" }}
+      {{ if not $featured }}{{ $featured = $images.GetMatch . }}{{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{/* fallback to default */}}
+  {{ if not (or $featured $featuredURL) }}
+    {{ $default := site.Store.Get "defaultFeaturedImage" }}
+    {{ if $default.url }}
+      {{ $featuredURL = $default.url }}
+    {{ else if $default.obj }}
+      {{ $featured = $default.obj }}
+    {{ end }}
+  {{ end }}
+
+  {{/* generate image URL if not hotlink */}}
+  {{ if not $featuredURL }}
+    {{ with $featured }}
+      {{ $featuredURL = .RelPermalink }}
+      {{ if not (or $disableImageOptimization (eq .MediaType.SubType "svg")) }}
+        {{ $featuredURL = (.Resize "600x").RelPermalink }}
+        {{ $featuredAvifURL = (.Resize "600x avif").RelPermalink }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+
+<article
+  class="article-link--related relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
+  {{ with $featuredURL }}
+    <div class="flex-none relative overflow-hidden thumbnail_card_related" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
+      <picture>
+        {{ with $featuredAvifURL }}
+          <source srcset="{{ . }}" type="image/avif">
+        {{ end }}
+        <img
+          src="{{ . }}"
+          role="presentation"
+          loading="lazy"
+          decoding="async"
+          fetchpriority="low"
+          class="not-prose absolute inset-0 w-full h-full object-cover">
+      </picture>
+    </div>
+  {{ end }}
+  {{ if and .Draft .Site.Params.article.showDraftLabel }}
+    <span class="absolute top-0 right-0 m-2">
+      {{ partial "badge.html" (i18n "article.draft" | emojify) }}
+    </span>
+  {{ end }}
+  <div class="p-4">
+    <header>
+      <a
+        {{ with $page.Params.externalUrl }}
+          href="{{ . }}" target="_blank" rel="external"
+        {{ else }}
+          href="{{ $page.RelPermalink }}"
+        {{ end }}
+        class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        <h2>
+          {{ .Title | emojify }}
+          {{ if .Params.externalUrl }}
+            <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+              <span class="rtl:hidden">&#8599;</span>
+              <span class="ltr:hidden">&#8598;</span>
+            </span>
+          {{ end }}
+        </h2>
+      </a>
+    </header>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{ partial "article-meta/basic.html" . }}
+    </div>
+    {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+      <div class="article-link__summary prose dark:prose-invert mt-1 line-clamp-5">
+        {{ .Summary | plainify }}
+      </div>
+    {{ end }}
+  </div>
+  <div class="px-6 pt-4 pb-2"></div>
+</article>

--- a/layouts/partials/article-link/card.html
+++ b/layouts/partials/article-link/card.html
@@ -1,0 +1,115 @@
+{{/* Used by
+  1. list.html and term.html (when the cardView option is enabled)
+  2. Recent articles template (when the cardView option is enabled)
+  3. Shortcode list.html
+*/}}
+{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+
+{{ $page := .Page }}
+{{ $featured := "" }}
+{{ $featuredURL := "" }}
+{{ $featuredAvifURL := "" }}
+{{ $thumbnailAspectRatio := site.Params.thumbnailAspectRatio | default "1.5" }}
+{{ $thumbnailAspectRatio = replaceRE "[^0-9.]" "" $thumbnailAspectRatio }}
+{{ if eq $thumbnailAspectRatio "" }}{{ $thumbnailAspectRatio = "1.5" }}{{ end }}
+{{ if not .Params.hideFeatureImage }}
+  {{/* frontmatter */}}
+  {{ with $page }}
+    {{ $p := . }}
+    {{ with .Params.featureimage }}
+      {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+        {{ if site.Params.hotlinkFeatureImage }}
+          {{ $featuredURL = . }}
+        {{ else }}
+          {{ $featured = resources.GetRemote . }}
+        {{ end }}
+      {{ else }}
+        {{ $featured = $p.Resources.Get . }}
+      {{ end }}
+    {{ end }}
+
+    {{/* page resources */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $images := .Resources.ByType "image" }}
+      {{ range slice "*feature*" "*cover*" "*thumbnail*" }}
+        {{ if not $featured }}{{ $featured = $images.GetMatch . }}{{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{/* fallback to default */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $default := site.Store.Get "defaultFeaturedImage" }}
+      {{ if $default.url }}
+        {{ $featuredURL = $default.url }}
+      {{ else if $default.obj }}
+        {{ $featured = $default.obj }}
+      {{ end }}
+    {{ end }}
+
+    {{/* generate image URL if not hotlink */}}
+    {{ if not $featuredURL }}
+      {{ with $featured }}
+        {{ $featuredURL = .RelPermalink }}
+        {{ if not (or $disableImageOptimization (eq .MediaType.SubType "svg")) }}
+          {{ $featuredURL = (.Resize "600x").RelPermalink }}
+          {{ $featuredAvifURL = (.Resize "600x avif").RelPermalink }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+
+<article
+  class="article-link--card relative min-h-full min-w-full overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600">
+  {{ with $featuredURL }}
+    <div class="flex-none relative overflow-hidden thumbnail_card" style="--thumbnail-aspect-ratio: {{ $thumbnailAspectRatio }}">
+      <picture>
+        {{ with $featuredAvifURL }}
+          <source srcset="{{ . }}" type="image/avif">
+        {{ end }}
+        <img
+          src="{{ . }}"
+          role="presentation"
+          loading="lazy"
+          decoding="async"
+          class="not-prose absolute inset-0 w-full h-full object-cover">
+      </picture>
+    </div>
+  {{ end }}
+  {{ if and .Draft .Site.Params.article.showDraftLabel }}
+    <span class="absolute top-0 right-0 m-2">
+      {{ partial "badge.html" (i18n "article.draft" | emojify) }}
+    </span>
+  {{ end }}
+  <div class="p-4">
+    <header>
+      <a
+        {{ with $page.Params.externalUrl }}
+          href="{{ . }}" target="_blank" rel="external"
+        {{ else }}
+          href="{{ $page.RelPermalink }}"
+        {{ end }}
+        class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        <h2>
+          {{ .Title | emojify }}
+          {{ if .Params.externalUrl }}
+            <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+              <span class="rtl:hidden">&#8599;</span>
+              <span class="ltr:hidden">&#8598;</span>
+            </span>
+          {{ end }}
+        </h2>
+      </a>
+    </header>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{ partial "article-meta/basic.html" . }}
+    </div>
+    {{ if .Params.showSummary | default (.Site.Params.list.showSummary | default false) }}
+      <div class="article-link__summary prose dark:prose-invert mt-1 line-clamp-5">
+        {{ .Summary | plainify }}
+      </div>
+    {{ end }}
+  </div>
+  <div class="px-6 pt-4 pb-2"></div>
+</article>

--- a/layouts/partials/article-link/simple.html
+++ b/layouts/partials/article-link/simple.html
@@ -1,0 +1,131 @@
+{{/* Used by
+  1. list.html and term.html (when the cardView option is not enabled)
+  2. Recent articles template (when the cardView option is not enabled)
+  3. Shortcode list.html
+*/}}
+{{ $constrainItemsWidth := site.Params.list.constrainItemsWidth | default false }}
+{{ $disableImageOptimization := site.Store.Get "disableImageOptimization" }}
+
+{{ $cardClasses := "flex flex-col md:flex-row relative" }}
+{{ $imgWrapperClasses := "" }}
+{{ $cardContentClasses := "" }}
+
+{{ if .Params.showCards | default site.Params.list.showCards }}
+  {{ $cardClasses = printf "%s overflow-hidden rounded-lg border border-neutral-300 dark:border-neutral-600" $cardClasses }}
+  {{ $imgWrapperClasses = "" }}
+  {{ $cardContentClasses = printf "%s p-4" $cardContentClasses }}
+{{ else }}
+  {{ $cardClasses = $cardClasses }}
+  {{ $imgWrapperClasses = printf "%s thumbnail-shadow md:mr-7" $imgWrapperClasses }}
+  {{ $cardContentClasses = printf "%s mt-3 md:mt-0" $cardContentClasses }}
+{{ end }}
+
+{{ if $constrainItemsWidth }}
+  {{ $cardClasses = printf "%s max-w-prose" $cardClasses }}
+{{ end }}
+
+{{ $page := .Page }}
+{{ $featured := "" }}
+{{ $featuredURL := "" }}
+{{ $featuredAvifURL := "" }}
+{{ if not .Params.hideFeatureImage }}
+  {{/* frontmatter */}}
+  {{ with $page }}
+    {{ $p := . }}
+    {{ with .Params.featureimage }}
+      {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+        {{ if site.Params.hotlinkFeatureImage }}
+          {{ $featuredURL = . }}
+        {{ else }}
+          {{ $featured = resources.GetRemote . }}
+        {{ end }}
+      {{ else }}
+        {{ $featured = $p.Resources.Get . }}
+      {{ end }}
+    {{ end }}
+
+    {{/* page resources */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $images := .Resources.ByType "image" }}
+      {{ range slice "*feature*" "*cover*" "*thumbnail*" }}
+        {{ if not $featured }}{{ $featured = $images.GetMatch . }}{{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{/* fallback to default */}}
+    {{ if not (or $featured $featuredURL) }}
+      {{ $default := site.Store.Get "defaultFeaturedImage" }}
+      {{ if $default.url }}
+        {{ $featuredURL = $default.url }}
+      {{ else if $default.obj }}
+        {{ $featured = $default.obj }}
+      {{ end }}
+    {{ end }}
+
+    {{/* generate image URL if not hotlink */}}
+    {{ if not $featuredURL }}
+      {{ with $featured }}
+        {{ $featuredURL = .RelPermalink }}
+        {{ if not (or $disableImageOptimization (eq .MediaType.SubType "svg")) }}
+          {{ $featuredURL = (.Resize "600x").RelPermalink }}
+          {{ $featuredAvifURL = (.Resize "600x avif").RelPermalink }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+
+<article class="article-link--simple {{ $cardClasses }}">
+  {{ with $featuredURL }}
+    <div class="flex-none relative overflow-hidden {{ $imgWrapperClasses }} thumbnail">
+      <picture>
+        {{ with $featuredAvifURL }}
+          <source srcset="{{ . }}" type="image/avif">
+        {{ end }}
+        <img
+          src="{{ . }}"
+          role="presentation"
+          loading="lazy"
+          decoding="async"
+          class="not-prose absolute inset-0 w-full h-full object-cover">
+      </picture>
+    </div>
+  {{ end }}
+  <div class="{{ $cardContentClasses }}">
+    <header class="items-center text-start text-xl font-semibold">
+      <a
+        {{ with $page.Params.externalUrl }}
+          href="{{ . }}" target="_blank" rel="external"
+        {{ else }}
+          href="{{ $page.RelPermalink }}"
+        {{ end }}
+        class="not-prose before:absolute before:inset-0 decoration-primary-500 dark:text-neutral text-xl font-bold text-neutral-800 hover:underline hover:underline-offset-2">
+        <h2>
+          {{ .Title | emojify }}
+          {{ if .Params.externalUrl }}
+            <span class="cursor-default align-top text-xs text-neutral-400 dark:text-neutral-500">
+              <span class="rtl:hidden">&#8599;</span>
+              <span class="ltr:hidden">&#8598;</span>
+            </span>
+          {{ end }}
+        </h2>
+      </a>
+      {{ if and .Draft .Site.Params.article.showDraftLabel }}
+        <div class="ms-2">{{ partial "badge.html" (i18n "article.draft" | emojify) }}</div>
+      {{ end }}
+      {{ if templates.Exists "partials/extend-article-link.html" }}
+        {{ partial "extend-article-link.html" . }}
+      {{ end }}
+    </header>
+    <div class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{ partial "article-meta/basic.html" . }}
+    </div>
+    {{ if .Params.showSummary | default (site.Params.list.showSummary | default false) }}
+      <div class="article-link__summary prose dark:prose-invert max-w-fit mt-1 line-clamp-3">
+        {{ .Summary | plainify }}
+      </div>
+    {{ end }}
+  </div>
+  <div class="px-6 pt-4 pb-2"></div>
+</article>

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,0 +1,71 @@
+{{ $disableImageOptimization := .Site.Params.disableImageOptimization | default false }}
+<div class="flex author">
+  {{ with .Site.Params.Author.image }}
+    {{ $authorImage := "" }}
+    {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+      {{ $authorImage = resources.GetRemote . }}
+    {{ else }}
+      {{ $authorImage = resources.Get . }}
+    {{ end }}
+    {{ if $authorImage }}
+      {{ $final := $authorImage }}
+      {{ $finalAvif := "" }}
+      {{ $squareImage := $authorImage }}
+      {{ if not (or $disableImageOptimization (eq $authorImage.MediaType.SubType "svg")) }}
+        {{ $final = $authorImage.Fill "192x192" }}
+        {{ $finalAvif = $authorImage.Fill "192x192 avif" }}
+        {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+        {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
+      {{ end }}
+      <picture>
+        {{ with $finalAvif }}
+          <source srcset="{{ .RelPermalink }}" type="image/avif">
+        {{ end }}
+        <img
+          class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
+          width="96"
+          height="96"
+          alt="{{ $.Site.Params.Author.name | default " Author" }}"
+          src="{{ $final.RelPermalink }}"
+          data-zoom-src="{{ $squareImage.RelPermalink }}">
+      </picture>
+    {{ else }}
+      {{ $authorImage := resources.GetRemote . }}
+      {{ $final := $authorImage }}
+      {{ $finalAvif := "" }}
+      {{ $squareImage := $authorImage }}
+      {{ if not $disableImageOptimization }}
+        {{ $final = $authorImage.Fill "192x192" }}
+        {{ $finalAvif = $authorImage.Fill "192x192 avif" }}
+        {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+        {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
+      {{ end }}
+      <picture>
+        {{ with $finalAvif }}
+          <source srcset="{{ .RelPermalink }}" type="image/avif">
+        {{ end }}
+        <img
+          class="!mt-0 !mb-0 h-24 w-24 rounded-full me-4"
+          width="96"
+          height="96"
+          alt="{{ $.Site.Params.Author.name | default " Author" }}"
+          src="{{ $final.RelPermalink }}"
+          data-zoom-src="{{ $squareImage.RelPermalink }}">
+      </picture>
+    {{ end }}
+  {{ end }}
+  <div class="place-self-center">
+    {{ with .Site.Params.Author.name | markdownify }}
+      <div class="text-[0.6rem] uppercase leading-3 text-neutral-500 dark:text-neutral-400">
+        {{ i18n "author.byline_title" | markdownify }}
+      </div>
+      <div class="font-semibold leading-6 text-neutral-800 dark:text-neutral-300">
+        {{ . }}
+      </div>
+    {{ end }}
+    {{ with .Site.Params.Author.bio | markdownify }}
+      <div class="text-sm text-neutral-700 dark:text-neutral-400">{{ . }}</div>
+    {{ end }}
+    <div class="text-2xl sm:text-lg">{{ partialCached "author-links.html" . }}</div>
+  </div>
+</div>

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -1,0 +1,54 @@
+{{ $disableImageOptimization := .Site.Params.disableImageOptimization | default false }}
+<article
+  class="{{ if not .Site.Params.homepage.showRecent }}
+    h-full
+  {{ end }} flex flex-col items-center justify-center text-center">
+  <header class="relative px-1 py-1 flex flex-col items-center mb-3">
+    {{ with .Site.Params.Author.image }}
+      {{ $authorImage := "" }}
+      {{ if or (strings.HasPrefix . "http:") (strings.HasPrefix . "https:") }}
+        {{ $authorImage = resources.GetRemote . }}
+      {{ else }}
+        {{ $authorImage = resources.Get . }}
+      {{ end }}
+      {{ if $authorImage }}
+        {{ $final := $authorImage }}
+        {{ $finalAvif := "" }}
+        {{ $squareImage := $authorImage }}
+        {{ if not (or $disableImageOptimization (eq $authorImage.MediaType.SubType "svg")) }}
+          {{ $final = $authorImage.Fill (print "288x288 q" ( $.Site.Params.Author.imagequality | default "96" )) }}
+          {{ $finalAvif = $authorImage.Fill (print "288x288 avif q" ( $.Site.Params.Author.imagequality | default "96" )) }}
+          {{ $shortSide := int (math.Min $authorImage.Width $authorImage.Height) }}
+          {{ $squareImage = $authorImage.Crop (printf "%dx%d" $shortSide $shortSide ) }}
+        {{ end }}
+        <picture>
+          {{ with $finalAvif }}
+            <source srcset="{{ .RelPermalink }}" type="image/avif">
+          {{ end }}
+          <img
+            class="mb-2 h-36 w-36 rounded-full"
+            width="144"
+            height="144"
+            alt="{{ $.Site.Params.Author.name | default `Author` }}"
+            src="{{ $final.RelPermalink }}"
+            data-zoom-src="{{ $squareImage.RelPermalink }}">
+        </picture>
+      {{ end }}
+    {{ end }}
+    <h1 class="text-4xl font-extrabold">
+      {{ .Site.Params.Author.name | default .Site.Title }}
+    </h1>
+    {{ with .Site.Params.Author.headline }}
+      <h2 class="text-xl text-neutral-500 dark:text-neutral-400">
+        {{ . | markdownify }}
+      </h2>
+    {{ end }}
+    <div class="mt-1 text-2xl">
+      {{ partialCached "author-links.html" . }}
+    </div>
+  </header>
+  <section class="prose dark:prose-invert w-full">{{ .Content }}</section>
+</article>
+<section>
+  {{ partial "recent-articles/main.html" . }}
+</section>


### PR DESCRIPTION
## Summary

Add native AVIF generation via Hugo v0.162+ built-in image pipeline across the entire Blowfish site — article content, card thumbnails, profile image, and author avatar — using `<picture>` elements with AVIF → original format fallback.

## Changes

### `config/_default/hugo.toml`
- Add `resampleFilter: lanczos` for sharper downscaling
- Add `[imaging.avif]` — lossy, quality 65, encoderSpeed 10
- Add `[imaging.webp]` — lossy, quality 80

### New site-level overrides (non-destructive — Hugo lookup order prefers site over theme)

| File | Coverage |
|------|----------|
| `layouts/_default/_markup/render-image.html` | Article content images via markdown `![alt](src)` |
| `layouts/partials/article-link/card.html` | Article list cards (cardView) |
| `layouts/partials/article-link/card-related.html` | Related articles section |
| `layouts/partials/article-link/simple.html` | Article list links (non-cardView) |
| `layouts/partials/article-link/_shortcode.html` | Article shortcode |
| `layouts/partials/home/profile.html` | Home page author avatar |
| `layouts/partials/author.html` | Article page author avatar |

Each override preserves the original layout, CSS classes, and Blowfish-specific attributes (lazy loading, data-zoom-src, thumbnail aspect ratios).

## Performance

| Item | Value |
|------|-------|
| Build time (first/cached) | ~25s / <1s (encoderSpeed=10) |
| Images processed | 154 |
| Pages with AVIF `<picture>` | Home + article lists + article pages |